### PR TITLE
Enhance README and documentation for P2P sync and OTP compatibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,9 +43,10 @@ logic:
 | **Desktop** (Electron, macOS/Ubuntu) | 🔜 planned | GitHub Releases (`.dmg`/`.deb`) |
 | **Mobile** (React Native, iOS/Android) | 🔜 planned | App Store / Play Store |
 
-Devices will sync **peer-to-peer over local Wi-Fi/Bluetooth — no backend
-server**. Each device keeps its own encrypted vault; sync is an explicit,
-local, device-to-device merge.
+Devices will sync **peer-to-peer over the local network, QR-paired — no
+backend server, no account, and no permissions beyond the camera and iOS's
+local-network prompt**. Each device keeps its own encrypted vault; sync is
+an explicit, local, device-to-device merge.
 
 ## Repository structure
 
@@ -186,10 +187,12 @@ Development is staged; each stage has an in-depth design doc in
 | A1 ✅ | Extract shared core, monorepo restructure, publish hardening | [doc](docs/plan/stage-a1-extract-core.md) |
 | A2 ✅ | Vault format versioning, AES-GCM upgrade, migrations, test suite | [doc](docs/plan/stage-a2-vault-migration.md) |
 | B ✅ | CLI: single-account CRUD, code/copy/qr/export, otplib removal | [doc](docs/plan/stage-b-cli-account-management.md) |
-| C | P2P sync v1: PAKE pairing, Wi-Fi/mDNS transport, LWW merge | [doc](docs/plan/stage-c-sync-protocol.md) |
+| B2 | Full OTP compatibility (8-digit/60s/SHA-256/HOTP/Steam), Aegis/2FAS/andOTP imports, paper backup | [doc](docs/plan/stage-b2-otp-compat-and-imports.md) |
+| C | P2P sync v1: QR-paired local sync, minimal permissions, LWW merge | [doc](docs/plan/stage-c-sync-protocol.md) |
 | D | Electron desktop app (macOS/Ubuntu) | [doc](docs/plan/stage-d-desktop-electron.md) |
 | E | React Native mobile app (iOS/Android) | [doc](docs/plan/stage-e-mobile-react-native.md) |
 | F | CI, packaging, store submissions | [doc](docs/plan/stage-f-distribution.md) |
+| G | Browser extension (desktop-app native messaging) | [doc](docs/plan/stage-g-browser-extension.md) |
 
 ## Contributing
 

--- a/docs/plan/00-overview.md
+++ b/docs/plan/00-overview.md
@@ -12,7 +12,7 @@ Future: the same account vault, usable from three surfaces —
 - Desktop app for Mac/Ubuntu (Electron)
 - Mobile app for iPhone/Android (React Native)
 
-— kept in sync **peer-to-peer over local Wi-Fi / Bluetooth, with no backend
+— kept in sync **peer-to-peer over the local network, QR-paired, with no backend
 server**. Each device holds its own encrypted vault; sync is an explicit,
 local, device-to-device operation, not a hosted service.
 
@@ -54,18 +54,20 @@ painful.
 
 | Stage | One-line scope | Depth doc |
 |---|---|---|
-| A1 | Extract current logic into `packages/core`, zero behavior change | [stage-a1-extract-core.md](stage-a1-extract-core.md) |
-| A2 | Vault versioning + migrations (storage path, GCM upgrade, id/timestamps) | [stage-a2-vault-migration.md](stage-a2-vault-migration.md) |
-| B | CLI: single add/delete/rename, `--list`, merge-on-import | [stage-b-cli-account-management.md](stage-b-cli-account-management.md) |
-| C | Sync v1: PAKE pairing, Wi-Fi/mDNS transport, BLE proximity, LWW merge | [stage-c-sync-protocol.md](stage-c-sync-protocol.md) |
+| A1 ✅ | Extract current logic into `packages/core`, zero behavior change | [stage-a1-extract-core.md](stage-a1-extract-core.md) |
+| A2 ✅ | Vault versioning + migrations (storage path, GCM upgrade, id/timestamps) | [stage-a2-vault-migration.md](stage-a2-vault-migration.md) |
+| B ✅ | CLI: single-account CRUD, code/copy/qr/export, otplib removal | [stage-b-cli-account-management.md](stage-b-cli-account-management.md) |
+| B2 | Full OTP compatibility (8-digit/60s/SHA-256/HOTP/Steam), competitor imports, paper backup | [stage-b2-otp-compat-and-imports.md](stage-b2-otp-compat-and-imports.md) |
+| C | Sync v1: QR-paired high-entropy code, direct TCP, LWW merge, minimal permissions | [stage-c-sync-protocol.md](stage-c-sync-protocol.md) |
 | D | Electron desktop app | [stage-d-desktop-electron.md](stage-d-desktop-electron.md) |
 | E | React Native mobile app | [stage-e-mobile-react-native.md](stage-e-mobile-react-native.md) |
 | F | Distribution polish, CI, packaging | [stage-f-distribution.md](stage-f-distribution.md) |
+| G | Browser extension via desktop-app native messaging (outline) | [stage-g-browser-extension.md](stage-g-browser-extension.md) |
 
 ## Cross-cutting non-goals (v1)
 
-- No relay/internet sync when devices aren't on the same LAN or in BLE range —
-  pure local-first, matching the explicit "no backend for now" requirement.
+- No relay/internet sync when devices can't reach each other on a local
+  network — pure local-first, matching the explicit "no backend" requirement.
 - No multi-user / shared-vault concept — one vault per device identity, synced
   copies, not a shared server-side record.
 - No changes to the public CLI command surface in Stage A — `--import`,

--- a/docs/plan/stage-b2-otp-compat-and-imports.md
+++ b/docs/plan/stage-b2-otp-compat-and-imports.md
@@ -1,0 +1,67 @@
+# Stage B2 — Full OTP compatibility + competitor imports + paper backup
+
+Slots between B and C: independent of sync, smaller in scope, and it
+strengthens core (and the market position) before the sync work begins.
+Born out of the July 2026 competitor research — these are the gaps that
+make switching to (or fully onto) this app hard today.
+
+## 1. Full OTP compatibility
+
+**Bug being fixed:** Google Authenticator imports carry `digits`,
+`algorithm`, and (in otpauth URIs) `period` — but `updateTotp`/`--run`/
+`--totp` currently hardcode 6 digits / 30s / SHA-1. An 8-digit or 60-second
+account imports "successfully" and then renders wrong codes. Table stakes
+in Aegis/Ente/2FAS.
+
+- Honor per-account `digits` (6/7/8), `period` (15/30/60), `algorithm`
+  (SHA-1/SHA-256/SHA-512) end to end: `generateTotp` already accepts
+  options — the fix is plumbing account fields through `updateTotp`, the
+  run view, `--totp`, `--copy`, and the otpauth importer (parse `digits=`,
+  `period=`, `algorithm=` query params).
+- `CryptoProvider` gains `hmac(algorithm, key, data)`; `hmacSha1` becomes a
+  deprecated alias until Stage E's RN provider lands.
+- **HOTP (RFC 4226):** accept `otpauth://hotp/` (currently rejected),
+  persist the per-account `counter`, increment on generation.
+  `--run` shows HOTP accounts with a "press to generate" hint rather than a
+  countdown; `--totp <name>` generates and bumps the counter.
+- **Steam Guard:** 5-character alphanumeric alphabet mode
+  (`steam://` secrets / `type: STEAM`), as Aegis and Ente support.
+- Per-interval expiry display: the run view's countdown currently assumes
+  30s for all rows (`getTimeout()` global) — becomes per-account.
+
+Tests: RFC 6238 SHA-256/512 vectors, RFC 4226 HOTP vectors, Steam known
+pairs, importer parsing of digits/period/algorithm.
+
+## 2. Competitor imports (kill the lock-in pain)
+
+Parsers in `packages/core/src/importers/`, auto-detected by
+`--import <file>` (same detection chain that today distinguishes backup
+files from URIs), merged through the existing `merge()` machinery:
+
+- **Aegis** JSON export — plain and encrypted (scrypt + AES-256-GCM; our
+  CryptoProvider already speaks both primitives)
+- **2FAS** backup file (plain + encrypted variants)
+- **andOTP** JSON export
+
+Each parser maps to `OtpAccount` and goes through the same merge/conflict
+rules as Stage B. Import from Authy is deliberately out of scope (no
+sanctioned export exists — that's *their* lock-in, and exactly why users
+switch to apps like this one).
+
+## 3. Paper backup sheet
+
+`auth --export --paper [file.html]`: renders the **encrypted** backup
+(same format as `--export`) as QR code(s) in a printable self-contained
+HTML file — offline, fireproof-safe disaster recovery that no competitor
+CLI offers. Restore: scan with the mobile app (Stage E) or point
+`--import` at the decoded payload. Reuses `qrcode-terminal`'s underlying
+QR generation or embeds the QR as SVG; the backup password chosen at
+export time remains the only key — a found sheet without the password is
+useless.
+
+## Non-goals
+
+- No permission additions on any platform (see Stage C's permissions
+  budget — camera-based restore already exists in the Stage E scope)
+- No new dependencies beyond what's already shipped; encrypted competitor
+  formats are decoded with in-repo crypto

--- a/docs/plan/stage-c-sync-protocol.md
+++ b/docs/plan/stage-c-sync-protocol.md
@@ -2,92 +2,150 @@
 
 ## Goal
 
-Sync vaults across devices with **no backend**, over local Wi-Fi and/or
-Bluetooth proximity. This is the riskiest new engineering in the whole plan
-(new protocol, security-sensitive, cross-platform networking quirks) — prove
-it CLI-to-CLI over a LAN before any Electron/RN UI is built on top of it.
+Sync vaults across devices with **no backend**, over the local network,
+QR-paired, with the smallest possible permission footprint. This is the
+riskiest new engineering in the whole plan (new protocol,
+security-sensitive, cross-platform networking quirks) — prove it CLI-to-CLI
+over a LAN before any Electron/RN UI is built on top of it.
 
-## Pairing: PAKE, not "compare codes visually"
+## Why this is the product's differentiator (market research, July 2026)
 
-Earlier drafts of this plan suggested showing a code on both devices and
-visually confirming a match. Better: a **password-authenticated key
-exchange (PAKE)** — SPAKE2 is the concrete candidate, the same family of
-idea behind `magic-wormhole`. One short one-time code (e.g. 6-8 characters,
-base32), typed into *either* device, cryptographically derives a shared
-session key. Properties that matter here:
+Every mainstream authenticator has a structural gap this stage exploits:
 
-- Works headless — no camera or display required, so it's uniform across
-  CLI (text prompt), Electron (GUI input), and RN (GUI input or QR scan as
-  a convenience wrapper around typing the same code)
-- Resistant to on-path attackers on the same Wi-Fi — unlike a bare "compare
-  these two numbers," a PAKE means an attacker who doesn't know the code
-  can't derive the session key even if they can see all the traffic
-- QR code (mobile convenience) just encodes { host, port, one-time-code } —
-  it is not a separate security mechanism, it's a scan-instead-of-type UX
-  wrapper around the same PAKE code
+- **Google Authenticator** — cloud sync is *not* end-to-end encrypted
+  (Google holds the keys); historically weak export.
+- **Authy** — closed source; 2024 Twilio breach exposed 33M account phone
+  numbers; desktop app discontinued in 2024; notorious export lock-in.
+- **Aegis** — excellent local-first Android app, but Android-only and no
+  device sync at all.
+- **Ente Auth** — E2EE sync done right, but requires an account and their
+  (or a self-hosted) server.
+- **2FAS** — mobile-only; backups go to your own iCloud/Google Drive.
 
-## Transport: Wi-Fi/mDNS primary, BLE for mobile-mobile proximity only
+Nobody ships **CLI + desktop + mobile with serverless, account-less,
+local-only P2P sync**. That is this project's lane, and this stage builds
+its core. (Sources: ente.com/compare, stateofsurveillance.org 2FA guide,
+pwdfortress.com 2026 authenticator roundup.)
 
-- **Discovery:** mDNS/Bonjour on the local network (`bonjour`/`react-native-zeroconf`)
-- **Bulk transfer:** a local TCP/TLS (or WebSocket) connection once paired —
-  vault payloads are small (a handful of base32 secrets), so throughput is a
-  non-issue; the reason to prefer Wi-Fi over BLE is reliability and platform
-  support, not bandwidth
-- **Bluetooth's role:** proximity discovery/pairing for phone-to-phone only,
-  when two mobile devices aren't necessarily on the same Wi-Fi network.
-  Bluetooth support in Node/Electron (`noble`) is unreliable on modern macOS
-  and needs BlueZ + permissions on Linux — so desktop devices join sync via
-  Wi-Fi/mDNS, never BLE
-- **Fallback:** mDNS can be blocked by client isolation on hotel/corporate
-  Wi-Fi — provide a manual "enter host:port" path so LAN sync still works
-  without discovery
+## Permissions budget — the hard constraint
+
+Rule: **any feature that would add a permission must justify itself in this
+table first, and "convenience" is not a justification.** Current total:
+
+| Platform | Permission | Why | When requested |
+|---|---|---|---|
+| iOS | Camera | Scan import QR codes + sync pairing QR (already required by Stage E import) | First scan |
+| iOS | Local Network (`NSLocalNetworkUsageDescription`) | Unavoidable for *any* LAN connection since iOS 14 — even a direct socket to a QR-supplied IP | Just-in-time, only when the user starts a sync |
+| Android | Camera | Same as iOS | First scan |
+| Android | — | **Nothing else.** No Bluetooth cluster, no location, no `NEARBY_WIFI_DEVICES` (we use no Wi-Fi scanning APIs — see Transport) | — |
+
+Notably absent, by design:
+
+- **Bluetooth is dropped entirely** (earlier drafts used BLE for
+  phone-to-phone proximity). BLE would cost the `BLUETOOTH_SCAN/CONNECT/
+  ADVERTISE` cluster on Android 12+, *location* permission on older
+  Android, and flaky `noble` support on desktop. QR pairing carries the
+  address, so no radio discovery is needed. Phone↔phone without a shared
+  network: one phone enables its personal hotspot, the other joins — zero
+  extra permissions.
+- **No mDNS on mobile.** Discovery is an optional CLI/desktop convenience
+  (Node needs no OS permission for it); a phone never browses the network —
+  it dials exactly the `ip:port` its camera just scanned.
+
+iOS Local Network denial is handled gracefully: sync cannot work without it
+(the OS blocks the socket), so the app explains why and deep-links to
+Settings — no workaround, no nagging.
+
+## Pairing: high-entropy one-time code + HKDF (no PAKE needed)
+
+Earlier drafts specified SPAKE2. Review changed this: PAKE protocols exist
+to protect *low-entropy* codes from offline guessing, but the JS SPAKE2
+ecosystem is a stale npm package (6+ years unmaintained) or a Rust/WASM
+build that fights React Native — an unmaintained crypto dependency is
+exactly what the otplib removal taught us to avoid. Instead, make the code
+high-entropy and the problem disappears:
+
+- Host device generates a **one-time pairing secret ≥130 bits** (26-char
+  base32) and starts a one-shot listener.
+- **QR encodes `authsync://<ip>:<port>#<code>`** — scanning is the primary
+  mobile flow (camera permission only). CLI/desktop print the same URI as
+  text for copy/paste; typing 26 chars manually is the worst-case fallback
+  and acceptable for a rare pairing action.
+- Both sides derive the session key with **HKDF-SHA256(code, salt =
+  protocol transcript)** and speak **AES-256-GCM** frames via the existing
+  `CryptoProvider` — zero new dependencies, every primitive already in-repo
+  and tested.
+- An attacker on the same network who sees the traffic but not the QR/code
+  cannot derive the key (130 bits ≫ brute force), which is the same
+  property SPAKE2 provided for short codes.
+- The code is single-use: the listener dies after one session, success or
+  failure.
+
+## Transport
+
+- **Framing:** length-prefixed JSON messages, AES-256-GCM encrypted with
+  the session key, protocol-versioned (`{"proto":"SYNC/1"}` hello). Vault
+  payloads are tiny; throughput is irrelevant.
+- **Connection:** direct TCP. The joining side dials the address from the
+  QR/pasted URI. No listener runs outside an explicit sync session.
+- **Discovery (optional, CLI/desktop only):** mDNS/Bonjour so two
+  laptops can find each other without reading IPs aloud. Never on mobile.
+- **Universal fallback:** manual `host:port` entry (also covers
+  client-isolated hotel/corporate Wi-Fi where mDNS is blocked).
 
 ## Payload encryption
 
 The pairing session key encrypts the *transport* — it is layered on top of,
-not a replacement for, each account's existing vault-level encryption. If
-the receiving vault is itself password-protected, the transferred accounts
-still only decrypt with that vault's password.
+not a replacement for, vault-level encryption. If the receiving vault is
+password-protected, transferred accounts still only persist under that
+vault's own AES-256-GCM password encryption.
 
 ## Merge / conflict resolution
 
 Each account already carries `id`, `updatedAt`, `deletedAt` (added in Stage
-A2 specifically so this stage wouldn't need a schema migration). Merge two
-account sets by `id`:
+A2 for exactly this). Merge two account sets by `id`:
 
-- both present, different `updatedAt` → keep the newer (last-write-wins)
+- both present, different `updatedAt` → keep the newer (last-write-wins);
+  equal timestamps → deterministic tie-break by lexicographic `id`
 - present only remotely → add locally
 - present locally, `deletedAt` set remotely with a newer timestamp → delete
   locally (tombstone)
 
-This is sufficient for a low-write-frequency dataset like 2FA accounts — no
-need for full CRDTs.
+Accepted risk: LWW trusts device clocks. For a low-write dataset like 2FA
+accounts this is fine; a skewed clock can at worst resurrect/prefer a stale
+edit of a single account, visible in the merge summary. No CRDTs.
 
-## Platform permission gotchas to design around up front
+**Tombstone GC:** tombstones older than 90 days are purged on write —
+long-dead deletions don't ride along forever.
 
-- iOS 14+ prompts for "Local Network" access before any LAN discovery — the
-  RN app must handle the user denying this gracefully (fall back to manual
-  host:port or BLE)
-- Android requires *location* permission to do BLE scanning (an OS quirk
-  unrelated to actual location use) — needs a clear in-app explanation or
-  users will be confused/alarmed
-- Electron + `noble` Bluetooth is flaky enough on modern macOS/Linux that
-  desktop should not depend on it at all (see Transport section above)
+## Hardening rules
+
+- The listener binds only while `--sync` is running, accepts **exactly one
+  connection**, and exits after the merge (or on error/timeout).
+- **No silent writes:** the receiving side displays the merge summary
+  (N added / N updated / N deleted) and requires confirmation before the
+  vault is touched — same UX as Stage B's merge conflicts.
+- Malformed/oversized frames or a failed GCM tag abort the session
+  immediately; nothing partial is ever written.
 
 ## Build/prove order
 
-1. Implement pairing (SPAKE2) + transport (Wi-Fi/mDNS + manual fallback) +
-   merge logic entirely inside `@authenticator/core`
-2. Expose it via `authenticator --sync` in the CLI — two machines on the same
-   LAN, both running the CLI, pair and merge vaults. This is the real-world
-   test bed before investing in any GUI
-3. Only after CLI-to-CLI sync is proven reliable does Stage D/E wire the same
-   `core` sync APIs into Electron/RN UIs
+1. Pairing (code + HKDF), transport (framing + one-shot listener), and
+   merge logic land in `@authenticator/core` behind the existing adapter
+   seams, fully unit-tested (frame round-trip, tamper abort, merge matrix,
+   tombstone GC).
+2. `authenticator --sync` (host) / `authenticator --sync <uri-or-host:port>`
+   (join) in the CLI — two machines on one LAN are the test bed.
+3. Only after CLI↔CLI sync is proven do Stages D/E wire the same core APIs
+   into Electron/RN UIs (mobile adds only the QR scan wrapper).
 
 ## Explicit non-goals (v1)
 
-- No relay/internet sync when devices aren't on the same LAN or in BLE range
+- No relay/internet sync when devices can't reach each other locally
 - No continuous/background sync daemon — sync is an explicit, user-initiated
   action on both ends
-- No multi-device "source of truth" server — every device's vault is a
-  peer, merges are symmetric
+- No stored device trust / paired-devices list — every sync session pairs
+  fresh with a new code (simplest possible trust model; revisit only if
+  re-pairing friction proves real)
+- No multi-device "source of truth" — every vault is a peer, merges are
+  symmetric

--- a/docs/plan/stage-d-desktop-electron.md
+++ b/docs/plan/stage-d-desktop-electron.md
@@ -14,7 +14,7 @@ packages/desktop/
   src/main/              Electron main process — owns the vault (StorageAdapter,
                           CryptoProvider, sync networking), same as the CLI does
   src/renderer/           React UI — account list, live codes, add/remove/rename,
-                          sync pairing flow (enter/generate PAKE code)
+                          sync pairing flow (show/enter the one-time pairing code)
   src/preload.ts          IPC bridge exposing a narrow, typed API from main to
                           renderer (never expose raw fs/crypto to the renderer)
 ```
@@ -28,8 +28,9 @@ the vault password or raw ciphertext handling.
 - Account list view with live-refreshing codes (equivalent of `--run`)
 - Add/remove/rename accounts (equivalent of Stage B's CLI flags, as UI)
 - Import flow (paste or file-drop the Google Authenticator export URI)
-- Sync UI: "Pair with another device" → shows/accepts the PAKE code from
-  Stage C, then a merge confirmation before applying
+- Sync UI: "Pair with another device" → shows the `authsync://` pairing
+  code/QR from Stage C (or accepts a pasted one), then a merge confirmation
+  before applying
 - Password prompt / vault unlock screen on launch if encrypted
 
 ## Non-goals

--- a/docs/plan/stage-e-mobile-react-native.md
+++ b/docs/plan/stage-e-mobile-react-native.md
@@ -3,8 +3,9 @@
 ## Goal
 
 UI over `@authenticator/core`, using mobile-specific `StorageAdapter` and
-`CryptoProvider` implementations, plus native modules for BLE proximity
-pairing (Stage C).
+`CryptoProvider` implementations. No Bluetooth, no discovery — sync joins
+by dialing the address scanned from the host's pairing QR (see Stage C's
+permissions budget).
 
 ## Platform adapters needed
 
@@ -14,30 +15,37 @@ react-native-mmkv-based StorageAdapter implementation
 
 // crypto
 react-native-quick-crypto (or equivalent) CryptoProvider implementation —
-must support AES-256-GCM + scrypt to match core's expectations exactly
-
-// BLE (mobile-to-mobile pairing only, per Stage C)
-a native BLE module (e.g. react-native-ble-plx) wired to core's pairing
-handshake — BLE carries the PAKE handshake bytes only, not bulk vault data
+must support AES-256-GCM, scrypt, HKDF-SHA256, and hmac(algo) to match
+core's expectations exactly
 ```
 
-## Permission handling (see Stage C for why these exist)
+That's the whole list — the QR/direct-connect sync design (Stage C) means
+no BLE module, no zeroconf module, no Wi-Fi scanning API.
 
-- iOS: request Local Network permission before mDNS discovery; if denied,
-  fall back to manual host:port entry or BLE (phone-to-phone)
-- Android: request location permission before BLE scanning, with a clear
-  in-app explanation (this is an OS requirement unrelated to actual location
-  use — users will be confused if it's not explained)
+## Permission handling (see Stage C's permissions budget)
+
+- **Camera** (iOS + Android): import QR scanning and sync-pairing QR
+  scanning. Requested on first scan.
+- **iOS Local Network**: prompted by the OS the moment the sync socket
+  opens (unavoidable since iOS 14, even for a direct connection to a
+  QR-supplied IP). Requested just-in-time during sync only; on denial,
+  explain why sync can't work and deep-link to Settings — no workaround.
+- **Android: nothing further.** No Bluetooth cluster, no location, no
+  NEARBY_WIFI_DEVICES. This is a deliberate product stance, not an
+  accident — see the budget table in
+  [stage-c-sync-protocol.md](stage-c-sync-protocol.md).
 
 ## Scope for this stage
 
-- Account list with live-refreshing codes
-- Add/remove/rename accounts
+- Account list with live-refreshing codes (per-account digits/period from
+  Stage B2)
+- Add/remove/rename accounts; add via camera scan of a site's QR
 - Import via camera QR scan of a Google Authenticator export QR code
-  (a genuine mobile advantage over the CLI's current "decode the QR on a
-  third-party website" instruction)
-- Sync UI: scan a QR (wrapping the same PAKE code from Stage C) or BLE
-  proximity pairing with another phone
+  (a genuine mobile advantage over the CLI flow)
+- Restore from a paper backup sheet (Stage B2) by scanning it
+- Sync UI: scan the host device's pairing QR (`authsync://…`), or host a
+  sync session showing that QR; phone↔phone without shared Wi-Fi uses the
+  personal-hotspot path
 - Biometric unlock (Face ID/Touch ID/Android biometric) as a convenience
   layer in front of the vault password, not a replacement for it
 
@@ -45,4 +53,6 @@ handshake — BLE carries the PAKE handshake bytes only, not bulk vault data
 
 - No App Store/Play Store submission process yet — that's Stage F
 - No redesign of vault format/sync protocol — same core APIs proven in
-  Stages A-C
+  Stages A–C
+- No push notifications, no analytics, no account system — nothing that
+  would grow the permission budget or contradict the no-backend promise

--- a/docs/plan/stage-f-distribution.md
+++ b/docs/plan/stage-f-distribution.md
@@ -12,16 +12,19 @@ current repo along the way.
   currently reference CI that doesn't reflect the actual (lack of) test
   suite) — wire up real CI now that `core` has meaningful test coverage from
   Stage A2 onward
-- Drop `node-schedule` for a plain `setInterval` in the TOTP refresh loop —
-  one less dependency for what's a one-line interval timer
-- Bump `commander` (currently pinned old) and other stale deps in the CLI
-  package
+- ~~Drop `node-schedule`~~ ✅ done early (Stage A1 publish-readiness review);
+  ~~otplib~~ ✅ removed in Stage B; ~~protobufjs audit~~ ✅ fixed in the
+  post-B hotfix (PR #8)
+- Bump `commander` (currently pinned old) and any remaining stale deps in
+  the CLI package
 - Electron: code signing + notarization (macOS), packaging for
   `.dmg`/`.deb`/AppImage
-- React Native: App Store + Play Store submission (privacy manifest, permission
-  justifications for local network/Bluetooth/camera usage — reviewers will
-  ask why a 2FA app wants Bluetooth/local network access, so the sync
-  feature's purpose needs to be clearly stated in store listings)
+- React Native: App Store + Play Store submission (privacy manifest,
+  permission justifications for camera + iOS local-network usage per Stage
+  C's permissions budget — reviewers will ask why a 2FA app wants local
+  network access, so the local-sync purpose needs to be clearly stated in
+  store listings; the deliberately tiny permission set is itself a
+  review-friendliness and marketing point)
 - Decide on a shared product name/branding across CLI + desktop + mobile if
   they're meant to feel like one product family (open question, not blocking
   any earlier stage)

--- a/docs/plan/stage-g-browser-extension.md
+++ b/docs/plan/stage-g-browser-extension.md
@@ -1,0 +1,33 @@
+# Stage G — Browser extension (outline)
+
+> Future stage, strictly **after Stage D** (it needs the desktop app as its
+> local backend). Recorded now because the July 2026 competitor research
+> identified it as 2FAS's stand-out feature and a natural fit here.
+
+## Concept
+
+A browser extension (Chrome/Firefox) that fills the current TOTP code for
+the site you're on, by asking the **desktop app** — never by holding
+secrets itself.
+
+- **Transport: native messaging host**, not a network port. The browser
+  launches/talks to a registered helper binary over stdio — no listener, no
+  localhost socket to firewall, nothing another process on the LAN can
+  reach. This is the same minimal-permission philosophy as Stage C's
+  permissions budget applied to the desktop.
+- The extension holds zero secrets and zero vault state; every code is
+  requested per use, and the desktop app can require its vault to be
+  unlocked (and optionally re-prompt) before answering.
+- Domain matching: extension sends the page origin; desktop matches it
+  against account issuer/name and returns *only* the matching code —
+  the extension never sees the account list.
+- Explicit non-goals: no autofill without a user click, no background
+  polling, no cloud component, no Manifest V3 remote code.
+
+## Prior art
+
+2FAS Browser Extension (pairs with the phone app; ours pairs with the
+desktop app instead — no push infrastructure needed, which keeps the
+no-backend promise).
+
+Detailed design happens when Stage D is done and its IPC surface is known.


### PR DESCRIPTION
- Updated README.md to clarify the peer-to-peer sync mechanism, emphasizing QR pairing and minimal permissions.
- Revised documentation in 00-overview.md and stage-c-sync-protocol.md to reflect changes in sync protocol and permissions budget.
- Introduced stage-b2-otp-compat-and-imports.md detailing full OTP compatibility, competitor imports, and paper backup features.
- Adjusted stage-d-desktop-electron.md and stage-e-mobile-react-native.md to align with new sync UI and permission handling strategies.