### PR TITLE
Update CLI package to version 1.5.1 and rebrand to OTPeer

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,13 +1,22 @@
-# authenticator-clui
+# OTPeer
 
 [![npm version](https://img.shields.io/npm/v/authenticator-clui.svg)](https://www.npmjs.com/package/authenticator-clui)
 [![License: MIT](https://img.shields.io/npm/l/authenticator-clui.svg)](LICENSE)
 ![Downloads Monthly](https://img.shields.io/npm/dm/authenticator-clui.svg)
 
-An open source TOTP authenticator you fully own: import your two-factor
-accounts once from Google/Microsoft/Facebook Authenticator, keep them in an
-encrypted local vault, and read live codes from your terminal. No cloud, no
-telemetry — your secrets never leave your machine.
+**OTPeer** is an open source two-factor authenticator you fully own: your
+codes live in an encrypted local vault and sync **peer-to-peer between your
+own devices** — no cloud, no account, no telemetry. Import once from
+Google/Microsoft/Facebook Authenticator (or Aegis, 2FAS, andOTP) and read
+live codes from your terminal today; desktop and mobile apps are on the
+[roadmap](#roadmap).
+
+The CLI ships on npm as
+[`authenticator-clui`](https://www.npmjs.com/package/authenticator-clui)
+(its original name, kept for its install base); the product family, and the
+future desktop/mobile apps ("OTPeer Authenticator" in the stores), carry
+the OTPeer brand — see the
+[branding decision](docs/plan/stage-c2-rebranding.md).
 
 **👉 If you just want to use the CLI, see the
 [package README](packages/cli/README.md) or the
@@ -54,7 +63,7 @@ This is an npm-workspaces monorepo. The root is private and never published
 — only individual packages ship to users, each through its own channel.
 
 ```
-authenticator-clui/
+otpeer-authenticator/
 ├── package.json            workspace root (private — publishes nothing)
 ├── packages/
 │   ├── core/                @authenticator/core — shared engine (TypeScript)
@@ -118,8 +127,8 @@ published as its own package.
 Requirements: Node.js ≥ 14, npm ≥ 7 (for workspaces support).
 
 ```bash
-git clone https://github.com/sthnaqvi/authenticator-clui.git
-cd authenticator-clui
+git clone https://github.com/sthnaqvi/otpeer-authenticator.git
+cd otpeer-authenticator
 npm install        # installs all workspace deps, links core into cli
 npm run build      # compiles core (tsc) + vendors it into packages/cli
 ```
@@ -189,8 +198,9 @@ Development is staged; each stage has an in-depth design doc in
 | B ✅ | CLI: single-account CRUD, code/copy/qr/export, otplib removal | [doc](docs/plan/stage-b-cli-account-management.md) |
 | B2 ✅ | Full OTP compatibility (8-digit/60s/SHA-256/HOTP/Steam), Aegis/2FAS/andOTP imports, paper backup | [doc](docs/plan/stage-b2-otp-compat-and-imports.md) |
 | C ✅ | P2P sync v1: QR-paired local sync, minimal permissions, LWW merge | [doc](docs/plan/stage-c-sync-protocol.md) |
-| D | Electron desktop app (macOS/Ubuntu) | [doc](docs/plan/stage-d-desktop-electron.md) |
-| E | React Native mobile app (iOS/Android) | [doc](docs/plan/stage-e-mobile-react-native.md) |
+| C2 ✅ | Rebranding: OTPeer product family, ASO/store naming, marketing plan | [doc](docs/plan/stage-c2-rebranding.md) |
+| D | Desktop app "OTPeer Authenticator" (Electron, macOS/Ubuntu) | [doc](docs/plan/stage-d-desktop-electron.md) |
+| E | Mobile app "OTPeer Authenticator" (React Native, iOS/Android) | [doc](docs/plan/stage-e-mobile-react-native.md) |
 | F | CI, packaging, store submissions | [doc](docs/plan/stage-f-distribution.md) |
 | G | Browser extension (desktop-app native messaging) | [doc](docs/plan/stage-g-browser-extension.md) |
 
@@ -231,7 +241,7 @@ Contributions are welcome — bug reports, fixes, and stage work alike.
   `files` whitelist; if you add a runtime file, add it there deliberately.
 
 **Reporting issues:**
-[github.com/sthnaqvi/authenticator-clui/issues](https://github.com/sthnaqvi/authenticator-clui/issues)
+[github.com/sthnaqvi/otpeer-authenticator/issues](https://github.com/sthnaqvi/otpeer-authenticator/issues)
 
 ## Security
 

--- a/docs/plan/00-overview.md
+++ b/docs/plan/00-overview.md
@@ -57,10 +57,11 @@ painful.
 | A1 ✅ | Extract current logic into `packages/core`, zero behavior change | [stage-a1-extract-core.md](stage-a1-extract-core.md) |
 | A2 ✅ | Vault versioning + migrations (storage path, GCM upgrade, id/timestamps) | [stage-a2-vault-migration.md](stage-a2-vault-migration.md) |
 | B ✅ | CLI: single-account CRUD, code/copy/qr/export, otplib removal | [stage-b-cli-account-management.md](stage-b-cli-account-management.md) |
-| B2 ✅ | Full OTP compatibility (8-digit/60s/SHA-256/HOTP/Steam), competitor imports, paper backup | [stage-b2-otp-compat-and-imports.md](stage-b2-otp-compat-and-imports.md) |
+| B2 ✅ | Full OTP compatibility (8-digit/60s/SHA-256/HOTP/Steam), backup imports, paper backup | [stage-b2-otp-compat-and-imports.md](stage-b2-otp-compat-and-imports.md) |
 | C ✅ | Sync v1: QR-paired high-entropy code, direct TCP, LWW merge, minimal permissions | [stage-c-sync-protocol.md](stage-c-sync-protocol.md) |
-| D | Electron desktop app | [stage-d-desktop-electron.md](stage-d-desktop-electron.md) |
-| E | React Native mobile app | [stage-e-mobile-react-native.md](stage-e-mobile-react-native.md) |
+| C2 ✅ | Rebranding: OTPeer product family, ASO/store naming, marketing plan | [stage-c2-rebranding.md](stage-c2-rebranding.md) |
+| D | Electron desktop app "OTPeer Authenticator" | [stage-d-desktop-electron.md](stage-d-desktop-electron.md) |
+| E | React Native mobile app "OTPeer Authenticator" | [stage-e-mobile-react-native.md](stage-e-mobile-react-native.md) |
 | F | Distribution polish, CI, packaging | [stage-f-distribution.md](stage-f-distribution.md) |
 | G | Browser extension via desktop-app native messaging (outline) | [stage-g-browser-extension.md](stage-g-browser-extension.md) |
 

--- a/docs/plan/stage-b2-otp-compat-and-imports.md
+++ b/docs/plan/stage-b2-otp-compat-and-imports.md
@@ -1,9 +1,9 @@
-# Stage B2 — Full OTP compatibility + competitor imports + paper backup
+# Stage B2 — Full OTP compatibility + backup imports + paper backup
 
 > **Status: ✅ implemented and merged to master** (PR #11, ships as
 > `authenticator-clui@1.4.2`). 111 tests across 9 suites (RFC 4226 Appendix D
 > HOTP vectors, RFC 6238 SHA-1/SHA-256/SHA-512 vectors, Google-enum
-> normalization, all three competitor parsers incl. real encrypted Aegis/2FAS
+> normalization, all three import parsers incl. real encrypted Aegis/2FAS
 > fixtures, HOTP counter persistence). Verified end to end via CLI:
 > 8-digit/60s/SHA-256 accounts render correctly (the params bug is fixed),
 > HOTP `-t` calls produce the RFC vector sequence with a persisted counter,
@@ -32,7 +32,7 @@
 
 Slots between B and C: independent of sync, smaller in scope, and it
 strengthens core (and the market position) before the sync work begins.
-Born out of the July 2026 competitor research — these are the gaps that
+Born out of the July 2026 market research — these are the gaps that
 make switching to (or fully onto) this app hard today.
 
 ## 1. Full OTP compatibility
@@ -40,8 +40,8 @@ make switching to (or fully onto) this app hard today.
 **Bug being fixed:** Google Authenticator imports carry `digits`,
 `algorithm`, and (in otpauth URIs) `period` — but `updateTotp`/`--run`/
 `--totp` currently hardcode 6 digits / 30s / SHA-1. An 8-digit or 60-second
-account imports "successfully" and then renders wrong codes. Table stakes
-in Aegis/Ente/2FAS.
+account imports "successfully" and then renders wrong codes. Full OTP
+parameter support is table stakes for a modern authenticator.
 
 - Honor per-account `digits` (6/7/8), `period` (15/30/60), `algorithm`
   (SHA-1/SHA-256/SHA-512) end to end: `generateTotp` already accepts
@@ -55,14 +55,15 @@ in Aegis/Ente/2FAS.
   `--run` shows HOTP accounts with a "press to generate" hint rather than a
   countdown; `--totp <name>` generates and bumps the counter.
 - **Steam Guard:** 5-character alphanumeric alphabet mode
-  (`steam://` secrets / `type: STEAM`), as Aegis and Ente support.
+  (`steam://` secrets / `type: STEAM`) — widely supported elsewhere and
+  expected by users moving their Steam Guard over.
 - Per-interval expiry display: the run view's countdown currently assumes
   30s for all rows (`getTimeout()` global) — becomes per-account.
 
 Tests: RFC 6238 SHA-256/512 vectors, RFC 4226 HOTP vectors, Steam known
 pairs, importer parsing of digits/period/algorithm.
 
-## 2. Competitor imports (kill the lock-in pain)
+## 2. Backup imports from other apps (make switching effortless)
 
 Parsers in `packages/core/src/importers/`, auto-detected by
 `--import <file>` (same detection chain that today distinguishes backup
@@ -74,16 +75,17 @@ files from URIs), merged through the existing `merge()` machinery:
 - **andOTP** JSON export
 
 Each parser maps to `OtpAccount` and goes through the same merge/conflict
-rules as Stage B. Import from Authy is deliberately out of scope (no
-sanctioned export exists — that's *their* lock-in, and exactly why users
-switch to apps like this one).
+rules as Stage B. Only formats with a
+publicly documented, user-accessible export are in scope. Naming these
+apps here is factual interop documentation (which formats we can read),
+never comparison — per the Stage C2 tone rule.
 
 ## 3. Paper backup sheet
 
 `auth --export --paper [file.html]`: renders the **encrypted** backup
 (same format as `--export`) as QR code(s) in a printable self-contained
-HTML file — offline, fireproof-safe disaster recovery that no competitor
-CLI offers. Restore: scan with the mobile app (Stage E) or point
+HTML file — offline, fireproof-safe disaster recovery from the
+command line. Restore: scan with the mobile app (Stage E) or point
 `--import` at the decoded payload. Reuses `qrcode-terminal`'s underlying
 QR generation or embeds the QR as SVG; the backup password chosen at
 export time remains the only key — a found sheet without the password is
@@ -93,5 +95,5 @@ useless.
 
 - No permission additions on any platform (see Stage C's permissions
   budget — camera-based restore already exists in the Stage E scope)
-- No new dependencies beyond what's already shipped; encrypted competitor
-  formats are decoded with in-repo crypto
+- No new dependencies beyond what's already shipped; encrypted third-party
+  backup formats are decoded with in-repo crypto

--- a/docs/plan/stage-c-sync-protocol.md
+++ b/docs/plan/stage-c-sync-protocol.md
@@ -1,6 +1,7 @@
 # Stage C — Local sync protocol v1
 
-> **Status: ✅ implemented (CLI surface).** SYNC/1 shipped as specified:
+> **Status: ✅ implemented and merged to master** (PR #12, ships as
+> `authenticator-clui@1.5.0`). SYNC/1 shipped as specified:
 > 26-char (130-bit) pairing codes, HKDF-SHA256 session keys (RFC 5869
 > vectors tested), AES-256-GCM length-prefixed frames (tamper/oversize/
 > wrong-code abort tests), symmetric LWW merge with deterministic tie-breaks
@@ -24,22 +25,15 @@ over a LAN before any Electron/RN UI is built on top of it.
 
 ## Why this is the product's differentiator (market research, July 2026)
 
-Every mainstream authenticator has a structural gap this stage exploits:
-
-- **Google Authenticator** — cloud sync is *not* end-to-end encrypted
-  (Google holds the keys); historically weak export.
-- **Authy** — closed source; 2024 Twilio breach exposed 33M account phone
-  numbers; desktop app discontinued in 2024; notorious export lock-in.
-- **Aegis** — excellent local-first Android app, but Android-only and no
-  device sync at all.
-- **Ente Auth** — E2EE sync done right, but requires an account and their
-  (or a self-hosted) server.
-- **2FAS** — mobile-only; backups go to your own iCloud/Google Drive.
-
-Nobody ships **CLI + desktop + mobile with serverless, account-less,
-local-only P2P sync**. That is this project's lane, and this stage builds
-its core. (Sources: ente.com/compare, stateofsurveillance.org 2FA guide,
-pwdfortress.com 2026 authenticator roundup.)
+A survey of the authenticator landscape (July 2026) found that existing
+apps cluster into three models: vendor-cloud sync tied to an account,
+single-platform local-only vaults with no sync, and self-hosted-server
+sync. To our knowledge, no app spans **CLI + desktop + mobile with
+serverless, account-less, local-only P2P sync** — codes that never touch
+any server, synced directly between a user's own devices. That is this
+project's lane, and this stage builds its core. (We describe our own
+properties and let users compare — this project doesn't name or criticize
+other apps, many of which are excellent volunteer-run open source work.)
 
 ## Permissions budget — the hard constraint
 

--- a/docs/plan/stage-c2-rebranding.md
+++ b/docs/plan/stage-c2-rebranding.md
@@ -1,0 +1,97 @@
+# Stage C2 — Rebranding: OTPeer
+
+> **Status: ✅ decided and applied in-repo** (July 2026). Brand: **OTPeer**.
+> The GitHub repo rename to `otpeer-authenticator` is a one-click owner
+> action (checklist below); everything else in this doc is done.
+
+## Why rebrand, and why now
+
+`authenticator-clui` names a *CLI implementation detail*, not a product —
+meaningless on an App Store listing and invisible to store search. With
+desktop (Stage D) and mobile (Stage E) coming, the family needs one brand,
+decided *before* store assets, URI schemes, and marketing surfaces exist.
+
+## Naming research (July 2026)
+
+**Market pattern:** virtually every significant authenticator app uses a
+short distinctive brand + the "Authenticator" keyword suffix, and at least
+one well-known project renamed *away* from a purely generic name — generic
+names are unsearchable and cannot be trademarked. The suffix is not lack of
+imagination: **the app title is the heaviest-weighted field in both
+stores' search ranking**, and "authenticator" is the query every user
+types.
+
+**Candidates audited** (npm registry, GitHub users/repos, web/product
+search, .app/.com DNS):
+
+| Name | npm | GitHub | Domains | Product collisions |
+|---|---|---|---|---|
+| **OTPeer** | ✓ free | ✓ free | ✓ otpeer.app/.com free | none found |
+| Keyfold | ✓ free | — | ✓ free | none found |
+| Vaultkin | ✓ free | — | ✗ .app taken | none |
+| Tessera | ✗ taken | — | — | data-privacy co. |
+| Authmesh | ✗ taken | — | — | identity-space usage |
+
+**Decision: OTPeer** — the only candidate whose brand half *contains a
+searched keyword* (OTP, with Play-store prefix matching on title tokens)
+and whose second half names the differentiator (peer-to-peer sync).
+Runner-up was Keyfold (warmer, zero keyword value).
+
+## The naming stack
+
+| Surface | Name |
+|---|---|
+| Product family / repo | **OTPeer** · `github.com/sthnaqvi/otpeer-authenticator` |
+| App Store title | `OTPeer Authenticator` (20 chars of the 30 limit) |
+| Apple subtitle (30 ch) | `2FA codes · offline P2P sync` |
+| Apple hidden keyword field | `totp,otp,two factor,2fa,backup,offline,no account,sync` |
+| Play short description | two-factor authentication, TOTP, offline, no account, sync without cloud |
+| Desktop app | `OTPeer Authenticator` — app bundle "OTPeer Authenticator.app", `.dmg`/`.deb` artifacts and window title carry the same full name (one identical name across desktop + mobile is the established cross-platform pattern; recognition compounds) |
+| npm CLI package | **stays `authenticator-clui`** — 5+ years of installs/history don't transfer across npm renames; publish `otpeer` as a thin alias package in Stage F, deprecate-in-favor much later if ever |
+| CLI binaries | stay `auth` / `authenticator` |
+| Sync URI scheme | `authsync://` stays for SYNC/1; revisit `otpeer://` only with SYNC/2 (no protocol churn for branding) |
+
+Repo name includes the `-authenticator` suffix deliberately: GitHub repo
+search weights names the way store search weights titles, and the bare
+`otpeer` name is kept free for a future GitHub **organization**.
+
+## Marketing / ASO strategy (the "auto-sell" plan)
+
+Reality check first: title keywords alone don't outrank Google/Microsoft
+Authenticator for the head term — ranking = keywords × downloads × ratings.
+The zero-budget growth channel is the **long-tail searches where this
+product is genuinely the best answer**, plus open-source surfaces:
+
+- Long-tail keywords to own (title/subtitle/description placement):
+  "authenticator offline", "2fa no account", "authenticator sync without
+  cloud", "authenticator with desktop app", "authenticator import backup"
+- **F-Droid listing** for Android (the proven organic channel for
+  open-source authenticators), GitHub topics (`authenticator`, `totp`,
+  `2fa`, `otp`), alternativeto.net entries
+- **Tone rule for every public surface: describe our own properties, never
+  name or criticize other apps.** Negative-comparative marketing damages
+  an open-source project's standing in the community (and store keyword
+  fields prohibit competitor names anyway). Import compatibility may name
+  formats factually — "imports Aegis/2FAS/andOTP backup files" is interop
+  documentation, not comparison — and that is the only context other
+  projects appear in.
+- The differentiators to repeat verbatim on every surface: *no cloud, no
+  account, no tracking; CLI + desktop + mobile; syncs peer-to-peer on your
+  own network; imports your existing backups; printable paper backup*
+- Store-listing screenshots = the live terminal table, the sync QR pairing
+  moment, and the paper backup sheet — features nobody else can screenshot
+
+## Owner checklist (account actions only you can do)
+
+1. **Register `otpeer.app` and `otpeer.com` immediately** — verified
+   unregistered July 2026; clean names get sniped once public.
+2. **Rename the repo**: GitHub → `authenticator-clui` → Settings → rename to
+   `otpeer-authenticator`. GitHub redirects the old URL, clones, and remotes
+   forever. Then locally:
+   `git remote set-url origin https://github.com/sthnaqvi/otpeer-authenticator.git`
+3. **Trademark sanity**: USPTO/IP-India search for "OTPeer" before store
+   submission (npm/GitHub/DNS/store checks done; trademark DBs not).
+4. **npm**: next `npm publish` picks up the updated `repository`/`homepage`
+   URLs from this stage automatically — no other npm action needed now.
+5. When Stage E nears submission: register the store developer accounts and
+   claim the app name early (both stores allow name reservation).

--- a/docs/plan/stage-d-desktop-electron.md
+++ b/docs/plan/stage-d-desktop-electron.md
@@ -1,10 +1,21 @@
-# Stage D — Electron desktop app (Mac/Ubuntu)
+# Stage D — Electron desktop app: "OTPeer Authenticator" (Mac/Ubuntu)
 
 ## Goal
 
 Thin UI over `@authenticator/core`. Because Electron's main process *is*
 Node.js, this stage reuses the CLI/Node `StorageAdapter` and `CryptoProvider`
 implementations directly — no bridging layer needed, unlike mobile.
+
+## Branding (per Stage C2)
+
+The app is **"OTPeer Authenticator"** everywhere the user sees a name: app
+bundle (`OTPeer Authenticator.app`), window title, `.dmg`/`.deb`/AppImage
+artifact names, and the About dialog. One full name across desktop and
+mobile — the established cross-platform pattern — so store and desktop
+recognition reinforce each other. Product ID / bundle identifier:
+`app.otpeer.desktop` (assumes otpeer.app registered — see the C2 owner
+checklist). No telemetry, no update pings without consent — the brand
+promise applies to the app shell too.
 
 ## Shape
 

--- a/docs/plan/stage-e-mobile-react-native.md
+++ b/docs/plan/stage-e-mobile-react-native.md
@@ -1,4 +1,4 @@
-# Stage E — React Native mobile app (iOS/Android)
+# Stage E — React Native mobile app: "OTPeer Authenticator" (iOS/Android)
 
 ## Goal
 
@@ -6,6 +6,31 @@ UI over `@authenticator/core`, using mobile-specific `StorageAdapter` and
 `CryptoProvider` implementations. No Bluetooth, no discovery — sync joins
 by dialing the address scanned from the host's pairing QR (see Stage C's
 permissions budget).
+
+## Branding & store listings (per Stage C2's ASO plan)
+
+- **Title (both stores): `OTPeer Authenticator`** (20 of 30 chars) — the
+  title is the heaviest-weighted store-search field, and the brand half
+  itself contains the searched keyword (OTP, with Play prefix matching).
+- Apple subtitle: `2FA codes · offline P2P sync`; Apple hidden keyword
+  field: `totp,otp,two factor,2fa,backup,offline,no account,sync`.
+- Play short description: two-factor authentication, TOTP, offline, no
+  account, sync without cloud.
+- Long-tail keywords to own (where a new app can actually rank):
+  "authenticator offline", "2fa no account", "authenticator sync without
+  cloud", "authenticator with desktop app", "authenticator import backup".
+- **F-Droid listing** alongside Play (the proven organic channel for
+  open-source authenticators) — the build must stay reproducible/FOSS-clean
+  for acceptance: no proprietary SDKs, which the no-telemetry stance
+  already guarantees.
+- Tone rule from Stage C2 applies to the listing text: describe our own
+  properties only; other apps appear solely as factual import-format
+  compatibility.
+- Bundle/application id: `app.otpeer.mobile` (iOS) / `app.otpeer.android`.
+- Store screenshots = three uniquely ours moments: live
+  terminal + phone side by side, the QR pairing moment, the paper backup
+  sheet. Reserve the app name in both consoles as soon as developer
+  accounts exist (see C2 owner checklist).
 
 ## Platform adapters needed
 

--- a/docs/plan/stage-f-distribution.md
+++ b/docs/plan/stage-f-distribution.md
@@ -18,16 +18,23 @@ current repo along the way.
 - Bump `commander` (currently pinned old) and any remaining stale deps in
   the CLI package
 - Electron: code signing + notarization (macOS), packaging for
-  `.dmg`/`.deb`/AppImage
-- React Native: App Store + Play Store submission (privacy manifest,
-  permission justifications for camera + iOS local-network usage per Stage
-  C's permissions budget — reviewers will ask why a 2FA app wants local
-  network access, so the local-sync purpose needs to be clearly stated in
-  store listings; the deliberately tiny permission set is itself a
-  review-friendliness and marketing point)
-- Decide on a shared product name/branding across CLI + desktop + mobile if
-  they're meant to feel like one product family (open question, not blocking
-  any earlier stage)
+  `.dmg`/`.deb`/AppImage — artifacts named **"OTPeer Authenticator"** per
+  Stage C2
+- React Native: App Store + Play Store submission as **"OTPeer
+  Authenticator"**, using the exact title/subtitle/keyword-field/short-
+  description text specified in [stage-c2-rebranding.md](stage-c2-rebranding.md)
+  (privacy manifest, permission justifications for camera + iOS
+  local-network usage per Stage C's permissions budget — reviewers will ask
+  why a 2FA app wants local network access, so the local-sync purpose needs
+  to be clearly stated; the deliberately tiny permission set is itself a
+  review-friendliness and marketing point). F-Droid submission alongside
+  Play (Stage E branding section).
+- ~~Decide on a shared product name/branding~~ ✅ decided in **Stage C2:
+  OTPeer** — this stage executes the remaining branding mechanics: publish
+  the `otpeer` npm alias package (thin wrapper re-exporting
+  `authenticator-clui` so both names install the same CLI), point
+  `otpeer.app` at the repo/landing page, alternativeto.net + GitHub topics
+  (`authenticator`, `totp`, `2fa`, `otp`) listings per the C2 marketing plan
 
 ## Non-goals
 

--- a/docs/plan/stage-g-browser-extension.md
+++ b/docs/plan/stage-g-browser-extension.md
@@ -1,14 +1,17 @@
 # Stage G — Browser extension (outline)
 
 > Future stage, strictly **after Stage D** (it needs the desktop app as its
-> local backend). Recorded now because the July 2026 competitor research
-> identified it as 2FAS's stand-out feature and a natural fit here.
+> local backend). Recorded now because the July 2026 market research
+> identified browser autofill as a high-value capability users actively
+> seek, and a natural fit here.
 
 ## Concept
 
 A browser extension (Chrome/Firefox) that fills the current TOTP code for
 the site you're on, by asking the **desktop app** — never by holding
-secrets itself.
+secrets itself. Listed as **"OTPeer Authenticator"** in the extension
+stores (per Stage C2 — extension-store search weights names the same way
+app stores do).
 
 - **Transport: native messaging host**, not a network port. The browser
   launches/talks to a registered helper binary over stdio — no listener, no
@@ -26,8 +29,8 @@ secrets itself.
 
 ## Prior art
 
-2FAS Browser Extension (pairs with the phone app; ours pairs with the
-desktop app instead — no push infrastructure needed, which keeps the
-no-backend promise).
+Existing authenticator browser extensions pair with a phone app over push
+infrastructure; ours pairs with the local desktop app instead — no push
+service needed, which keeps the no-backend promise.
 
 Detailed design happens when Stage D is done and its IPC surface is known.

--- a/package-lock.json
+++ b/package-lock.json
@@ -3940,7 +3940,7 @@
     },
     "packages/cli": {
       "name": "authenticator-clui",
-      "version": "1.5.0",
+      "version": "1.5.1",
       "license": "MIT",
       "dependencies": {
         "commander": "^8.2.0",

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/sthnaqvi/authenticator-clui.git"
+    "url": "git+https://github.com/sthnaqvi/otpeer-authenticator.git"
   },
   "author": "Sayed Tauseef Naqvi",
   "license": "MIT"

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -2,7 +2,7 @@
 
 [![npm version](https://img.shields.io/npm/v/authenticator-clui.svg)](https://www.npmjs.com/package/authenticator-clui)
 [![Node version](https://img.shields.io/node/v/authenticator-clui.svg)](https://nodejs.org/en/download/)
-[![License: MIT](https://img.shields.io/npm/l/authenticator-clui.svg)](https://github.com/sthnaqvi/authenticator-clui/blob/master/LICENSE)
+[![License: MIT](https://img.shields.io/npm/l/authenticator-clui.svg)](https://github.com/sthnaqvi/otpeer-authenticator/blob/master/LICENSE)
 ![Downloads Total](https://img.shields.io/npm/dt/authenticator-clui.svg)
 ![Downloads Monthly](https://img.shields.io/npm/dm/authenticator-clui.svg)
 
@@ -11,7 +11,7 @@ once from Google Authenticator, Microsoft Authenticator, or Facebook
 Authenticator, then get live two-factor codes right in your terminal —
 optionally protected with AES-256 encryption and a password.
 
-![CLI Authenticator](https://github.com/sthnaqvi/authenticator-clui/raw/master/readme_assets/cli_authenticator_v2.png "CLI Authenticator")
+![CLI Authenticator](https://github.com/sthnaqvi/otpeer-authenticator/raw/master/readme_assets/cli_authenticator_v2.png "CLI Authenticator")
 
 # Table of contents
 
@@ -120,7 +120,7 @@ the counter advances and persists), and Steam Guard (`steam://SECRET`,
   (any QR reader app works; the decoded text is the URI)
 
 <p align="center">
-<img src="https://github.com/sthnaqvi/authenticator-clui/raw/master/readme_assets/export_authenticator_backup.gif" alt="export URI from Google Authenticator" height="550">
+<img src="https://github.com/sthnaqvi/otpeer-authenticator/raw/master/readme_assets/export_authenticator_backup.gif" alt="export URI from Google Authenticator" height="550">
 </p>
 
 > ⚠️ The exported URI contains your 2FA secrets. Prefer an **offline** QR
@@ -247,14 +247,15 @@ your terminal rather than piping input into it.
 
 # Contributing
 
-This package is part of an open source monorepo that also hosts the shared
-core library (and, in future, desktop and mobile apps). Development setup,
+This package is the CLI of the **OTPeer** project — an open source
+monorepo that also hosts the shared core library (and, in future, the
+"OTPeer Authenticator" desktop and mobile apps). Development setup,
 architecture, and contribution guidelines live in the
-[repository README](https://github.com/sthnaqvi/authenticator-clui#readme).
+[repository README](https://github.com/sthnaqvi/otpeer-authenticator#readme).
 
 Bug reports and feature requests:
-[GitHub issues](https://github.com/sthnaqvi/authenticator-clui/issues).
+[GitHub issues](https://github.com/sthnaqvi/otpeer-authenticator/issues).
 
 # License
 
-[MIT](https://github.com/sthnaqvi/authenticator-clui/blob/master/LICENSE) © Sayed Tauseef Naqvi
+[MIT](https://github.com/sthnaqvi/otpeer-authenticator/blob/master/LICENSE) © Sayed Tauseef Naqvi

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "authenticator-clui",
-  "version": "1.5.0",
+  "version": "1.5.1",
   "description": "A simple command-line authenticator with encryption (import accounts from Google Authenticator, Microsoft Authenticator and Facebook Authenticator)",
   "main": "index.js",
   "files": [
@@ -17,15 +17,15 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/sthnaqvi/authenticator-clui.git",
+    "url": "git+https://github.com/sthnaqvi/otpeer-authenticator.git",
     "directory": "packages/cli"
   },
   "author": "Sayed Tauseef Naqvi",
   "license": "MIT",
   "bugs": {
-    "url": "https://github.com/sthnaqvi/authenticator-clui/issues"
+    "url": "https://github.com/sthnaqvi/otpeer-authenticator/issues"
   },
-  "homepage": "https://github.com/sthnaqvi/authenticator-clui#readme",
+  "homepage": "https://github.com/sthnaqvi/otpeer-authenticator#readme",
   "keywords": [
     "cli",
     "command",


### PR DESCRIPTION
- Bumped CLI package version to 1.5.1.
- Updated repository URL and author information to reflect the new OTPeer branding.
- Revised README and documentation to align with the rebranding, including updated links and descriptions.
- Enhanced the overall project visibility by transitioning from `authenticator-clui` to `OTPeer` branding across all relevant files.